### PR TITLE
Add MVP server and homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # HackerGO
+
+This repository contains early prototype assets for the HackerGO concept. The `Web-app demo` folder now includes a minimal web application that can be served locally.
+
+## Running the MVP
+
+1. Install Node.js (version 20 or later).
+2. From the repository root, run:
+
+   ```bash
+   node server.js
+   ```
+
+3. Open `http://localhost:3000` in your web browser to see the app.
+
+The server is intentionally lightweight and only serves the existing static pages as a proof of concept.

--- a/Web-app demo/Main.html
+++ b/Web-app demo/Main.html
@@ -1,12 +1,22 @@
 <html>
-    <head>
-        <meta charset="utf-8">
-        <title>Hacker Go</title>
-        <link rel="stylesheet" href="static/css/open.css">
-        <script src="static/js/open.js"></script>
-    </head>
-        <body>
-            <img src="static/img/Main.png" alt="Main" class="BackGround">
-            <button class="button"><a href=Onboarding.html>Proceed</a></button>
-        </body>
+  <head>
+    <meta charset="utf-8">
+    <title>HackerGO</title>
+    <link rel="stylesheet" href="static/css/Main.css">
+    <script defer src="static/js/Main.js"></script>
+  </head>
+  <body>
+    <header>
+      <h1>HackerGO</h1>
+    </header>
+    <nav>
+      <a href="Onboarding.html">Onboarding</a>
+      <a href="#" data-section="host">Host</a>
+      <a href="#" data-section="connect">Connect</a>
+      <a href="#" data-section="leaderboard">Leaderboard</a>
+    </nav>
+    <div id="content">
+      Select an option from the menu.
+    </div>
+  </body>
 </html>

--- a/Web-app demo/static/css/Main.css
+++ b/Web-app demo/static/css/Main.css
@@ -1,0 +1,30 @@
+body {
+  background-color: #000;
+  color: #fff;
+  font-family: Arial, sans-serif;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+}
+
+header {
+  padding: 20px 0;
+}
+
+nav a {
+  color: #fff;
+  margin: 0 10px;
+  text-decoration: none;
+  border: 1px solid red;
+  padding: 8px 12px;
+  border-radius: 4px;
+}
+
+nav a:hover {
+  background: #fff;
+  color: #000;
+}
+
+#content {
+  margin-top: 40px;
+}

--- a/Web-app demo/static/js/Main.js
+++ b/Web-app demo/static/js/Main.js
@@ -1,0 +1,11 @@
+// Basic placeholder to swap content when menu links are clicked
+const links = document.querySelectorAll('nav a[data-section]');
+const content = document.getElementById('content');
+
+links.forEach(link => {
+  link.addEventListener('click', e => {
+    e.preventDefault();
+    const section = link.dataset.section;
+    content.textContent = `Selected section: ${section}`;
+  });
+});

--- a/server.js
+++ b/server.js
@@ -1,0 +1,47 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const baseDir = path.join(__dirname, 'Web-app demo');
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.png': 'image/png',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.avif': 'image/avif',
+  '.svg': 'image/svg+xml'
+};
+
+const server = http.createServer((req, res) => {
+  let filePath = req.url;
+  if (filePath === '/') filePath = '/Open.html';
+  filePath = path.join(baseDir, filePath);
+
+  fs.stat(filePath, (err, stats) => {
+    if (err) {
+      res.statusCode = 404;
+      res.end('Not found');
+      return;
+    }
+    if (stats.isDirectory()) filePath = path.join(filePath, 'index.html');
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        res.statusCode = 500;
+        res.end('Server error');
+        return;
+      }
+      const ext = path.extname(filePath).toLowerCase();
+      res.setHeader('Content-Type', mimeTypes[ext] || 'application/octet-stream');
+      res.end(data);
+    });
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`HackerGO MVP running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- serve prototype pages with a basic Node.js server
- flesh out `Main.html` as a simple home screen
- style and script the new home screen
- document how to run the minimal MVP
- ignore OS and node artifacts

## Testing
- `node server.js >/tmp/server.log 2>&1 &`
- `curl -I http://localhost:3000`


------
https://chatgpt.com/codex/tasks/task_e_685c356840008328be55f6808bbe32cd